### PR TITLE
A more sensible default for CM Auto Brightness on the Vision?

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -36,7 +36,7 @@
          Zone N:        array[N - 1] <= LUX < array[N]
          Zone N + 1:    array[N] <= LUX < infinity
 
-Must be overridden in platform specific overlays -->
+          Must be overridden in platform specific overlays -->
     <integer-array name="config_autoBrightnessLevels">
          <item>2</item>
          <item>4</item>
@@ -50,9 +50,9 @@ Must be overridden in platform specific overlays -->
     </integer-array>
 
     <!-- Array of output values for LCD backlight corresponding to the LUX values
-in the config_autoBrightnessLevels array. This array should have size one greater
-than the size of the config_autoBrightnessLevels array.
--->
+          in the config_autoBrightnessLevels array. This array should have size one greater
+          than the size of the config_autoBrightnessLevels array.
+          -->
     <integer-array name="config_autoBrightnessLcdBacklightValues">
         <item>40</item>
         <item>50</item>
@@ -67,9 +67,9 @@ than the size of the config_autoBrightnessLevels array.
     </integer-array>
 
     <!-- Array of output values for button backlight corresponding to the LUX values
-in the config_autoBrightnessLevels array. This array should have size one greater
-than the size of the config_autoBrightnessLevels array.
--->
+          in the config_autoBrightnessLevels array. This array should have size one greater
+          than the size of the config_autoBrightnessLevels array.
+          -->
     <integer-array name="config_autoBrightnessButtonBacklightValues">
         <item>4</item>
         <item>6</item>
@@ -84,10 +84,10 @@ than the size of the config_autoBrightnessLevels array.
     </integer-array>
 
     <!-- Array of output values for keyboard backlight corresponding to the LUX values
-in the config_autoBrightnessLevels array. This array should have size one greater
-than the size of the config_autoBrightnessLevels array.
-Passion has no keyboard so all values are zero.
--->
+          in the config_autoBrightnessLevels array. This array should have size one greater
+          than the size of the config_autoBrightnessLevels array.
+          Passion has no keyboard so all values are zero.
+          -->
     <integer-array name="config_autoBrightnessKeyboardBacklightValues">
         <item>255</item>
         <item>255</item>

--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -36,64 +36,64 @@
          Zone N:        array[N - 1] <= LUX < array[N]
          Zone N + 1:    array[N] <= LUX < infinity
 
-         Must be overridden in platform specific overlays -->
+Must be overridden in platform specific overlays -->
     <integer-array name="config_autoBrightnessLevels">
-        <item>11</item>
-        <item>41</item>
-        <item>91</item>
-        <item>161</item>
-        <item>226</item>
-        <item>321</item>
-        <item>641</item>
-        <item>1281</item>
-        <item>2601</item>
+         <item>2</item>
+         <item>4</item>
+         <item>10</item>
+         <item>22</item>
+         <item>42</item>
+         <item>123</item>
+         <item>260</item>
+         <item>392</item>
+         <item>714</item>
     </integer-array>
 
     <!-- Array of output values for LCD backlight corresponding to the LUX values
-         in the config_autoBrightnessLevels array.  This array should have size one greater
-         than the size of the config_autoBrightnessLevels array.
-    -->
+in the config_autoBrightnessLevels array. This array should have size one greater
+than the size of the config_autoBrightnessLevels array.
+-->
     <integer-array name="config_autoBrightnessLcdBacklightValues">
-        <item>89</item>
-        <item>89</item>
-        <item>126</item>
-        <item>164</item>
-        <item>164</item>
-        <item>164</item>
-        <item>187</item>
-        <item>210</item>
-        <item>233</item>
+        <item>40</item>
+        <item>50</item>
+        <item>60</item>
+        <item>75</item>
+        <item>90</item>
+        <item>110</item>
+        <item>140</item>
+        <item>190</item>
+        <item>255</item>
         <item>255</item>
     </integer-array>
 
     <!-- Array of output values for button backlight corresponding to the LUX values
-         in the config_autoBrightnessLevels array.  This array should have size one greater
-         than the size of the config_autoBrightnessLevels array.
-    -->
+in the config_autoBrightnessLevels array. This array should have size one greater
+than the size of the config_autoBrightnessLevels array.
+-->
     <integer-array name="config_autoBrightnessButtonBacklightValues">
+        <item>4</item>
+        <item>6</item>
+        <item>10</item>
+        <item>15</item>
+        <item>20</item>
         <item>30</item>
         <item>30</item>
-        <item>30</item>
-        <item>30</item>
-        <item>0</item>
-        <item>0</item>
-        <item>0</item>
         <item>0</item>
         <item>0</item>
         <item>0</item>
     </integer-array>
 
     <!-- Array of output values for keyboard backlight corresponding to the LUX values
-         in the config_autoBrightnessLevels array.  This array should have size one greater
-         than the size of the config_autoBrightnessLevels array.
-         Passion has no keyboard so all values are zero.
-    -->
+in the config_autoBrightnessLevels array. This array should have size one greater
+than the size of the config_autoBrightnessLevels array.
+Passion has no keyboard so all values are zero.
+-->
     <integer-array name="config_autoBrightnessKeyboardBacklightValues">
         <item>255</item>
         <item>255</item>
         <item>255</item>
         <item>255</item>
-        <item>0</item>
+        <item>255</item>
         <item>0</item>
         <item>0</item>
         <item>0</item>


### PR DESCRIPTION
Hi, I've tried to improve the default Auto Brightness settings for the Vision/G2.  The current default autobrightness ranges from 11..2601, which doesn't match the light sensor output from 1..1024. This means the auto brightness isn't responsive in dim-to-dark environments, and it skips steps.

This patch matches the overlay config.xml's "config_autoBrightnessLevels" to the existing libsensors/LightSensor.cpp.  Explanation below:

Since the HTC Vision's light sensor can only output 10 values (see LightSensor.cpp):

1 3 5 19 26 69 219 309 498 1024

...the config_autoBrightnessLevels array should have 10 'stops', equally spaced (on a log scale) between the possible lightsensor values, to make brightness transitions as smooth as possible while minimizing 'hunting'.

0 2 4 10 22 42 123 260 392 714

As for the values in the config_autoBrightnessLcdBacklightValues array, I started from a pitch-black-room screen brightness of 40, to a full-daylight brightness of 255, then interpolated with an exponential function (to match how the human eye sees brightness).  Feel free to brighten these values up if you think they will cause too many dim complaints.

I hope this might make its way to Andromadus, I'm loving their CM9 alpha.  Thanks!
